### PR TITLE
Fix two build errors

### DIFF
--- a/LaTeX/LTJournalArticle.cls
+++ b/LaTeX/LTJournalArticle.cls
@@ -68,7 +68,7 @@
 
 \linespread{1.05} % Increase line spacing slightly
 
-\usepackage{microtype} % Slightly tweak font spacing for aesthetics
+%\usepackage{microtype} % Slightly tweak font spacing for aesthetics
 
 %----------------------------------------------------------------------------------------
 %	HEADERS AND FOOTERS

--- a/LaTeX/template.tex
+++ b/LaTeX/template.tex
@@ -27,7 +27,7 @@
 	twoside, % Two side traditional mode where headers and footers change between odd and even pages, comment this option to make them fixed
 ]{LTJournalArticle}
 
-\addbibresource{sample.bib} % BibLaTeX bibliography file
+\addbibresource{bibliography.bib} % BibLaTeX bibliography file
 \renewcommand*{\bibfont}{\footnotesize}
 
 \runninghead{} % A shortened article title to appear in the running head, leave this command empty for no running head


### PR DESCRIPTION
This PR fixes two build errors that I saw:
- The microtype package caused a font error for me.
- The specified bibliography file did not exist, which showed up as a vague UTF8 error from Biber.