### PR TITLE
Fix: Use sample bibliography.

### DIFF
--- a/LaTeX/template.tex
+++ b/LaTeX/template.tex
@@ -27,7 +27,7 @@
 	twoside, % Two side traditional mode where headers and footers change between odd and even pages, comment this option to make them fixed
 ]{LTJournalArticle}
 
-\addbibresource{sample.bib} % BibLaTeX bibliography file
+\addbibresource{bibliography.bib} % BibLaTeX bibliography file
 \renewcommand*{\bibfont}{\footnotesize}
 
 \runninghead{} % A shortened article title to appear in the running head, leave this command empty for no running head


### PR DESCRIPTION
Template uses sample.bib from the latex distribution instead of the provided sample bibliography.